### PR TITLE
Fix AirPods Max (Headphone) battery in waybar and env file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -181,11 +181,13 @@ fn main() -> io::Result<()> {
                         let mut bat_left = None;
                         let mut bat_right = None;
                         let mut bat_case = None;
+                        let mut bat_headphone = None;
                         for b in infos {
                             match b.component {
                                 crate::bluetooth::aacp::BatteryComponent::Left => bat_left = Some(b.level),
                                 crate::bluetooth::aacp::BatteryComponent::Right => bat_right = Some(b.level),
                                 crate::bluetooth::aacp::BatteryComponent::Case if b.status != crate::bluetooth::aacp::BatteryStatus::Disconnected => bat_case = Some(b.level),
+                                crate::bluetooth::aacp::BatteryComponent::Headphone => bat_headphone = Some(b.level),
                                 _ => {}
                             }
                             if b.status == crate::bluetooth::aacp::BatteryStatus::NotCharging {
@@ -201,7 +203,7 @@ fn main() -> io::Result<()> {
                                 }
                             }
                         }
-                        crate::utils::write_battery_env(bat_left, bat_right, bat_case);
+                        crate::utils::write_battery_env(bat_left, bat_right, bat_case, bat_headphone);
                     }
                 }
             });
@@ -374,7 +376,7 @@ fn run_waybar_mode(watch: bool) -> io::Result<()> {
         let json = match app.selected_device() {
             Some(DeviceState::AirPods(s)) => {
                 let model_name = s.model.as_deref().unwrap_or(&s.name);
-                let min_bat = [s.battery_left, s.battery_right]
+                let min_bat = [s.battery_left, s.battery_right, s.battery_headphone]
                     .iter()
                     .filter_map(|b| b.as_ref().map(|(l, _)| *l))
                     .min();
@@ -384,6 +386,7 @@ fn run_waybar_mode(watch: bool) -> io::Result<()> {
                 if let Some((l, _)) = s.battery_left { tooltip_parts.push(format!("L: {}%", l)); }
                 if let Some((r, _)) = s.battery_right { tooltip_parts.push(format!("R: {}%", r)); }
                 if let Some((c, _)) = s.battery_case { tooltip_parts.push(format!("C: {}%", c)); }
+                if let Some((h, _)) = s.battery_headphone { tooltip_parts.push(format!("{}%", h)); }
                 let tooltip = tooltip_parts.join("\\n");
                 format!(
                     r#"{{"text":"{}","tooltip":"{}","class":"connected","percentage":{}}}"#,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -359,9 +359,10 @@ impl App {
                     let bat_left = state.battery_left.map(|(l, _)| l);
                     let bat_right = state.battery_right.map(|(r, _)| r);
                     let bat_case = state.battery_case.map(|(c, _)| c);
+                    let bat_headphone = state.battery_headphone.map(|(h, _)| h);
                     // Write battery env file in a background thread to avoid blocking the TUI loop
                     std::thread::spawn(move || {
-                        crate::utils::write_battery_env(bat_left, bat_right, bat_case);
+                        crate::utils::write_battery_env(bat_left, bat_right, bat_case, bat_headphone);
                     });
                 }
                 AACPEvent::DeviceInfo(info) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,11 +14,17 @@ pub fn runtime_dir() -> PathBuf {
 
 /// Write battery levels to `airpods-battery.env` in the runtime directory
 /// for external consumers (waybar, scripts).
-pub fn write_battery_env(left: Option<u8>, right: Option<u8>, case: Option<u8>) {
+pub fn write_battery_env(
+    left: Option<u8>,
+    right: Option<u8>,
+    case: Option<u8>,
+    headphone: Option<u8>,
+) {
     let mut content = String::new();
     if let Some(l) = left { content.push_str(&format!("LEFT={}\n", l)); }
     if let Some(r) = right { content.push_str(&format!("RIGHT={}\n", r)); }
     if let Some(c) = case { content.push_str(&format!("CASE={}\n", c)); }
+    if let Some(h) = headphone { content.push_str(&format!("HEADPHONE={}\n", h)); }
     if let Err(e) = std::fs::write(runtime_dir().join("airpods-battery.env"), content) {
         log::warn!("Failed to write airpods-battery.env: {}", e);
     }


### PR DESCRIPTION
## Summary

AirPods Max reports a single `Headphone` battery component rather than Left/Right. The TUI itself already handles this via `state.battery_headphone`, but the waybar JSON path and the env-file writer ignored it — so Max owners saw `0%` in waybar and had no `HEADPHONE=` entry in `/run/user/$UID/airpods-battery.env`.

- `run_waybar_mode`: include `battery_headphone` in `min_bat` and add a `{h}%` line to the tooltip
- `write_battery_env`: take a `headphone: Option<u8>` arg and write `HEADPHONE={}` when present
- Daemon `BatteryInfo` handler captures the `Headphone` variant alongside Left/Right/Case
- TUI passes `state.battery_headphone` through to `write_battery_env`

Regular AirPods (Left/Right/Case) output is unchanged.

## Test plan

- [x] `cargo build --release` passes
- [x] On AirPods Max, `airpods-tui --waybar` now returns `{"text":"32%","tooltip":"AirPods Max\n32%","class":"connected","percentage":32}` instead of `{"text":"0%",...}`
- [x] `/run/user/$UID/airpods-battery.env` now contains `HEADPHONE=32` while the daemon is running
- [x] Regression-check on a regular AirPods (not tested locally — no hardware)